### PR TITLE
🥣 RichTextSerializer

### DIFF
--- a/authors/models.py
+++ b/authors/models.py
@@ -7,17 +7,7 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.models import register_snippet
 from modelcluster.fields import ParentalKey
-from rest_framework.fields import Field
-
-
-class ImageSerializedField(Field):
-    def to_representation(self, value):
-        return {
-            'url': value.file.url,
-            'title': value.title,
-            'width': value.width,
-            'height': value.height,
-        }
+from ov_wag.serializers import ImageSerializedField
 
 
 class AuthorsOrderable(Orderable):

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -1,7 +1,6 @@
 from django.db import models
 from wagtail.core.models import Page
 from wagtail.core.fields import RichTextField
-from wagtail.core.templatetags import wagtailcore_tags
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.images.api.fields import ImageRenditionField
 from wagtail.search import index

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -1,11 +1,13 @@
 from django.db import models
 from wagtail.core.models import Page
 from wagtail.core.fields import RichTextField
+from wagtail.core.templatetags import wagtailcore_tags
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.images.api.fields import ImageRenditionField
 from wagtail.search import index
 from wagtail.api import APIField
 from pydantic import BaseModel
+from ov_wag.serializers import RichTextSerializer
 
 
 class ImageApiSchema(BaseModel):
@@ -55,7 +57,7 @@ class ExhibitPage(Page):
 
     api_fields = [
         APIField('title'),
-        APIField('body'),
+        APIField('body', serializer=RichTextSerializer()),
         APIField(
             'cover_image',
             serializer=ImageRenditionField('fill-1600x500'),

--- a/ov_wag/serializers.py
+++ b/ov_wag/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework.fields import Field
+from wagtail.core.templatetags import wagtailcore_tags
 
 
 class ImageSerializedField(Field):
@@ -9,3 +10,8 @@ class ImageSerializedField(Field):
             'width': value.width,
             'height': value.height,
         }
+
+
+class RichTextSerializer(Field):
+    def to_representation(self, value):
+        return wagtailcore_tags.richtext(value)

--- a/ov_wag/serializers.py
+++ b/ov_wag/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework.fields import Field
+
+
+class ImageSerializedField(Field):
+    def to_representation(self, value):
+        return {
+            'url': value.file.url,
+            'title': value.title,
+            'width': value.width,
+            'height': value.height,
+        }


### PR DESCRIPTION
# RichTextSerializer
- Creates `RichTextSerializer`
  - Transforms `<embed>` -> `<img>`
  - Exposed as `APIField` serializer for `Exhibit/body`
- Created `ov_wag/serializers.py`
  - Migrated `ImageSerializedField`

Closes #16