### PR TITLE
🎭 Production settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /app
 # Build the production image, with the application server
 FROM base as production
 
+# Create directory for logs
+RUN mkdir -p /logs
+
 # Set environment variables.
 # 1. Force Python stdout and stderr streams to be unbuffered.
 # 2. Set PORT variable that is used by Gunicorn. This should match "EXPOSE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,6 @@ services:
   db:
     image: postgres:14.2-alpine
     volumes:
-      - ./db:/var/lib/postgresql/data
+      - ./db:/var/lib/postgresql/data:Z
     user: ${UID}:${GID}
     restart: always

--- a/docker_entrypoints/deploy.sh
+++ b/docker_entrypoints/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gunicorn ov_wag.wsgi:application --reload
+gunicorn ov_wag.wsgi:application --reload --access-logfile /logs/access.log --error-logfile /logs/error.log

--- a/docker_entrypoints/deploy.sh
+++ b/docker_entrypoints/deploy.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-gunicorn ov_wag.wsgi:application --reload --access-logfile /logs/access.log --error-logfile /logs/error.log
+# Build static files for the admin site
+python3 manage.py collectstatic --noinput
+
+# Run the production server
+gunicorn ov_wag.wsgi:application \
+  --reload \
+  --access-logfile /logs/access.log \
+  --error-logfile /logs/error.log

--- a/ov_wag/settings/base.py
+++ b/ov_wag/settings/base.py
@@ -172,5 +172,4 @@ WAGTAILSEARCH_BACKENDS = {
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = 'http://example.com'
 WAGTAILAPI_BASE_URL = os.environ.get('OV_API_URL')

--- a/ov_wag/settings/production.py
+++ b/ov_wag/settings/production.py
@@ -1,6 +1,11 @@
 from .base import *
+from os import environ
 
 DEBUG = False
+ALLOWED_HOSTS = os.environ.get('OV_ALLOWED_HOSTS').split(',')
+WAGTAIL_BASE_URL = os.environ.get('OV_BASE_URL')
+
+SECRET_KEY = os.environ.get('OV_SECRET_KEY')
 
 try:
     from .local import *

--- a/ov_wag/settings/production.py
+++ b/ov_wag/settings/production.py
@@ -5,7 +5,7 @@ DEBUG = False
 ALLOWED_HOSTS = os.environ.get('OV_ALLOWED_HOSTS').split(',')
 WAGTAIL_BASE_URL = os.environ.get('OV_BASE_URL')
 
-CSRF_TRUSTED_ORIGINS = os.environ.get('OV_TRUSTED_ORIGINS')
+CSRF_TRUSTED_ORIGINS = os.environ.get('OV_TRUSTED_ORIGINS').split(',')
 
 SECRET_KEY = os.environ.get('OV_SECRET_KEY')
 

--- a/ov_wag/settings/production.py
+++ b/ov_wag/settings/production.py
@@ -5,6 +5,8 @@ DEBUG = False
 ALLOWED_HOSTS = os.environ.get('OV_ALLOWED_HOSTS').split(',')
 WAGTAIL_BASE_URL = os.environ.get('OV_BASE_URL')
 
+CSRF_TRUSTED_ORIGINS = os.environ.get('OV_TRUSTED_ORIGINS')
+
 SECRET_KEY = os.environ.get('OV_SECRET_KEY')
 
 try:

--- a/ov_wag/wsgi.py
+++ b/ov_wag/wsgi.py
@@ -7,10 +7,13 @@ For more information on this file, see
 https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/
 """
 
-import os
+from os import environ
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ov_wag.settings.dev")
+environ.setdefault(
+    'DJANGO_SETTINGS_MODULE',
+    environ.get('DJANGO_SETTINGS_MODULE', 'ov_wag.settings.dev'),
+)
 
 application = get_wsgi_application()


### PR DESCRIPTION
# Production Settings
Deploy all production settings in production environment.

## `production.py`
- Enables `production.py` settings file
  - `wsgi.py`: set `DJANGO_SETTINGS_MODULE` from env
  - default `ov_wag.settings.dev`
  - env override: `ov_wag.settings.production`
- Set `DEBUG=False`
- Set `ALLOWED_HOSTS` from env
  - `OV_ALLOWED_HOSTS=ov-wag`
- Set `CSRF_TRUSTED_ORIGINS`
  - `OV_TRUSTED_ORIGINS=http://ov-admin.k8s.wgbhdigital.org/`

Closes #48 

## Secrets
- Set `SECRET_KEY` from env secret

## Logging
Adds production logging:
- access: `/logs/access.log`
- errors: `/logs/error.log`

Closes #49 

## Media
- `./media` is mounted to volume
  - Also shared to `nginx` container

Closes #46 - until we switch to an external, s3 media solution.

## `deploy.sh`
- Adds `manage.py collectstatic` step to build static files for admin site