### PR TITLE
🥄 `ExhibitsSerializer`

### DIFF
--- a/authors/serializers.py
+++ b/authors/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework.fields import Field
+
+
+class AuthorsSerializer(Field):
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, value):
+        authors = value.exhibit.authors
+        image_serializer = ImageSerializedField()
+        return [
+            {
+                'id': author.id,
+                'name': author.name,
+                'image': image_serializer.to_representation(author.image),
+            }
+            for author in authors.all()
+        ]

--- a/authors/serializers.py
+++ b/authors/serializers.py
@@ -1,18 +1,20 @@
 from rest_framework.fields import Field
+from ov_wag.serializers import ImageSerializedField
+
+
+class AuthorSerializer(Field):
+    image = ImageSerializedField()
+
+    def to_representation(self, author):
+        return {
+            'id': author.author_id,
+            'name': author.name,
+            'image': self.image.to_representation(author.image),
+        }
 
 
 class AuthorsSerializer(Field):
-    def get_attribute(self, instance):
-        return instance
+    author = AuthorSerializer()
 
-    def to_representation(self, value):
-        authors = value.exhibit.authors
-        image_serializer = ImageSerializedField()
-        return [
-            {
-                'id': author.id,
-                'name': author.name,
-                'image': image_serializer.to_representation(author.image),
-            }
-            for author in authors.all()
-        ]
+    def to_representation(self, authors):
+        return [self.author.to_representation(author) for author in authors.all()]

--- a/exhibit/api.py
+++ b/exhibit/api.py
@@ -13,5 +13,4 @@ class ExhibitAPIViewSet(BaseAPIViewSet):
         'cover_thumb',
         'hero_image',
         'hero_thumb',
-        'other_exhibits',
     ]

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -12,6 +12,7 @@ from ov_wag.serializers import (
     ImageSerializedField,
     AuthorsSerializer,
 )
+from .serializers import ExhibitsSerializer
 
 
 class ExhibitsOrderable(Orderable):
@@ -120,5 +121,5 @@ class ExhibitPage(Page):
             serializer=ImageRenditionField('fill-480x270', source='hero_image'),
         ),
         APIField('authors'),
-        APIField('other_exhibits'),
+        APIField('other_exhibits', serializer=ExhibitsSerializer()),
     ]

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -117,6 +117,6 @@ class ExhibitPage(Page):
             'hero_thumb',
             serializer=ImageRenditionField('fill-480x270', source='hero_image'),
         ),
-        APIField('authors'),
+        APIField('authors', serializer=AuthorsSerializer()),
         APIField('other_exhibits', serializer=ExhibitsSerializer()),
     ]

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -7,11 +7,8 @@ from wagtail.search import index
 from wagtail.api import APIField
 from pydantic import BaseModel
 from modelcluster.fields import ParentalKey
-from ov_wag.serializers import (
-    RichTextSerializer,
-    ImageSerializedField,
-    AuthorsSerializer,
-)
+from ov_wag.serializers import RichTextSerializer, ImageSerializedField
+from authors.serializers import AuthorsSerializer
 from .serializers import ExhibitsSerializer
 
 

--- a/exhibit/serializers.py
+++ b/exhibit/serializers.py
@@ -1,26 +1,24 @@
 from rest_framework.fields import Field
 from ov_wag.serializers import ImageSerializedField
+from authors.serializers import AuthorsSerializer
 
 
 class ExhibitStubSerializer(Field):
-    image_serializer = ImageSerializedField()
+    image = ImageSerializedField()
+    authors = AuthorsSerializer()
 
     def to_representation(self, value):
         return {
-            'id': value.id,
+            'id': value.exhibit_id,
             'title': value.title,
-            'cover_image': self.image_serializer.to_representation(value.cover_image)
-            if value.cover_image
-            else None,
+            'cover_image': self.image.to_representation(value.cover_image),
+            'authors': self.authors.to_representation(value.authors),
         }
 
 
 class ExhibitsSerializer(Field):
-    exhibit_serializer = ExhibitStubSerializer()
-    image_serializer = ImageSerializedField()
+    exhibit = ExhibitStubSerializer()
+    image = ImageSerializedField()
 
     def to_representation(self, value):
-        return [
-            self.exhibit_serializer.to_representation(exhibit)
-            for exhibit in value.all()
-        ]
+        return [self.exhibit.to_representation(exhibit) for exhibit in value.all()]

--- a/exhibit/serializers.py
+++ b/exhibit/serializers.py
@@ -1,0 +1,26 @@
+from rest_framework.fields import Field
+from ov_wag.serializers import ImageSerializedField
+
+
+class ExhibitStubSerializer(Field):
+    image_serializer = ImageSerializedField()
+
+    def to_representation(self, value):
+        return {
+            'id': value.id,
+            'title': value.title,
+            'cover_image': self.image_serializer.to_representation(value.cover_image)
+            if value.cover_image
+            else None,
+        }
+
+
+class ExhibitsSerializer(Field):
+    exhibit_serializer = ExhibitStubSerializer()
+    image_serializer = ImageSerializedField()
+
+    def to_representation(self, value):
+        return [
+            self.exhibit_serializer.to_representation(exhibit)
+            for exhibit in value.all()
+        ]

--- a/ov
+++ b/ov
@@ -18,7 +18,7 @@ COMMANDS:\n\n
 
 COMPOSE="docker compose -f docker-compose.yml"
 DEV="-f dev.yml"
-MANAGE="run wagtail python3 manage.py"
+MANAGE="run --entrypoint python3 wagtail manage.py"
 
 if [ -z $1 ]; then
   echo -e $HELP

--- a/ov_wag/serializers.py
+++ b/ov_wag/serializers.py
@@ -15,20 +15,3 @@ class ImageSerializedField(Field):
 class RichTextSerializer(Field):
     def to_representation(self, value):
         return wagtailcore_tags.richtext(value)
-
-
-class AuthorsSerializer(Field):
-    def get_attribute(self, instance):
-        return instance
-
-    def to_representation(self, value):
-        authors = value.exhibit.authors
-        image_serializer = ImageSerializedField()
-        return [
-            {
-                'id': author.id,
-                'name': author.name,
-                'image': image_serializer.to_representation(author.image),
-            }
-            for author in authors.all()
-        ]

--- a/ov_wag/serializers.py
+++ b/ov_wag/serializers.py
@@ -4,12 +4,13 @@ from wagtail.core.templatetags import wagtailcore_tags
 
 class ImageSerializedField(Field):
     def to_representation(self, value):
-        return {
-            'url': value.file.url,
-            'title': value.title,
-            'width': value.width,
-            'height': value.height,
-        }
+        if value:
+            return {
+                'url': value.file.url,
+                'title': value.title,
+                'width': value.width,
+                'height': value.height,
+            }
 
 
 class RichTextSerializer(Field):


### PR DESCRIPTION
# `ExhibitsSerializer`
Create `ExhibitsSerializer` to customize values returned by API.
- returns list of `values.all()` as `ExhibitStubSerializer`
~~- Always returns 3 `other_exhibits`~~ Pushed to #58

## `ExhibitStubSerializer`
- `id`
- `title`
- `cover_image`
  - Serializes as `ImageSerializedField`

## `AuthorsSerializer`
Split single author into `AuthorSerializer`

## `AuthorSerializer`
- `id`
- `name`
- `image`

## misc
- Protect `ImageSerializedField` from error if no image
  - return None
- Remove `other_exhibits` from default `ExhibitAPIViewSet`
- Fix `./ov manage` to include `--entrypoint python3`