### PR TITLE
📈 Test Coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,17 @@
-name: ci
+name: 🧪 CI Tests
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: ☑️ Run Tests
-      run: ./ov test
+      - name: 📰 Checkout
+        uses: actions/checkout@v3
+
+      - name: ☑️ Run Tests
+        run: ./ov test

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -13,11 +13,6 @@ jobs:
       - name: ✅ Run Coverage Tests
         run: ./ov cover
 
-  coveralls:
-    name: 📈 Publish results to coveralls.io
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
       - name: 📔 Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,6 +1,10 @@
 name: 📈 Test Coverage
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,25 @@
+name: 📈 Test Coverage
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: 📝 Generate Coverage report
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📰 Checkout
+        uses: actions/checkout@v3
+
+      - name: ✅ Run Coverage Tests
+        run: ./ov cover
+
+  coveralls:
+    name: 📈 Publish results to coveralls.io
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📔 Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          path-to-lcov: coverage.lcov
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN pip install -r /requirements.txt
 
 WORKDIR /app
 
+# Build the test image, which includes the test applications
+FROM base as test
+COPY requirements-test.txt /
+RUN pip install -r /requirements-test.txt
+
 # Build the production image, with the application server
 FROM base as production
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ov-wag
 
-![CI](https://github.com/WGBH-MLA/ov-wag/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/WGBH-MLA/ov-wag/actions/workflows/ci.yml/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/WGBH-MLA/ov-wag/badge.svg)](https://coveralls.io/github/WGBH-MLA/ov-wag)
 
 Experimental - Open Vault Exhibits on Wagtail CMS
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   wagtail-tests:
     build:
       context: .
-      target: base
+      target: test
     image: ov-tests
     volumes:
       - ./:/app/

--- a/docker_entrypoints/test.sh
+++ b/docker_entrypoints/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python manage.py test
+pytest

--- a/exhibit/tests/factories.py
+++ b/exhibit/tests/factories.py
@@ -1,12 +1,13 @@
-import factory
-import wagtail_factories
+from factory import SubFactory
+from wagtail_factories import ImageChooserBlockFactory, PageFactory
 from exhibit.models import ExhibitPage
 
 
-class ExhibitPageFactory(wagtail_factories.PageFactory):
+class ExhibitPageFactory(PageFactory):
 
-    cover_image = factory.SubFactory(wagtail_factories.ImageChooserBlockFactory)
-    hero_image = factory.SubFactory(wagtail_factories.ImageChooserBlockFactory)
+    cover_image = SubFactory(ImageChooserBlockFactory)
+    hero_image = SubFactory(ImageChooserBlockFactory)
+    # other_exhibits =
 
     class Meta:
         model = ExhibitPage

--- a/exhibit/tests/test_exhibit_page.py
+++ b/exhibit/tests/test_exhibit_page.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
-from ..models import *
-from .factories import *
+from ..models import ExhibitPage
+from .factories import ExhibitPageFactory
 
 # Create your tests here.
 class ExhibitPageTests(TestCase):

--- a/ov
+++ b/ov
@@ -56,8 +56,9 @@ elif [ $1 = "test" -o $1 = "t" ]; then
 
 elif [ $1 = "coverage" -o $1 = "cover" ]; then
   shift
-  # Run tests in isolation
+  # Generate coverage report
   $COMPOSE run --entrypoint coverage wagtail-tests run -m pytest
+  $COMPOSE run --entrypoint coverage wagtail-tests lcov
 
 else echo -e $HELP
 

--- a/ov
+++ b/ov
@@ -9,6 +9,7 @@ COMMANDS:\n\n
 
 \t  b | build \t  build the docker image\n
 \t  c | cmd \t    run a bash command with the wagtail docker image\n
+\t  coverage \t   run the coverage tests
 \t  d | dev \t    start a development server\n
 \t  h | help \t   prints this help text\n
 \t  s | shell \t  enter into a python shell with the app context\n
@@ -52,6 +53,11 @@ elif [ $1 = "test" -o $1 = "t" ]; then
   shift
   # Run tests in isolation
   $COMPOSE run wagtail-tests
+
+elif [ $1 = "coverage" -o $1 = "cover" ]; then
+  shift
+  # Run tests in isolation
+  $COMPOSE run --entrypoint coverage wagtail-tests run -m pytest
 
 else echo -e $HELP
 

--- a/ov
+++ b/ov
@@ -8,7 +8,7 @@ USAGE:\n\n
 COMMANDS:\n\n
 
 \t  b | build \t  build the docker image\n
-\t  c | cmd \t    run a bash command with the docker image\n
+\t  c | cmd \t    run a bash command with the wagtail docker image\n
 \t  d | dev \t    start a development server\n
 \t  h | help \t   prints this help text\n
 \t  s | shell \t  enter into a python shell with the app context\n
@@ -18,7 +18,7 @@ COMMANDS:\n\n
 
 COMPOSE="docker compose -f docker-compose.yml"
 DEV="-f dev.yml"
-MANAGE="run wagtail python3 manage.py"
+MANAGE="run --entrypoint python wagtail manage.py"
 
 if [ -z $1 ]; then
   echo -e $HELP
@@ -43,9 +43,10 @@ elif [ $1 = "manage" -o $1 = "m" ]; then
   $COMPOSE $DEV $MANAGE "$@"
 
 elif [ $1 = "cmd" -o $1 = "c" ]; then
-  shift
+  ENTRYPOINT=$2
+  shift 2
   # docker run -it -v $(pwd)/:/app/ ov "$@"
-  $COMPOSE $DEV run -it wagtail "$@"
+  $COMPOSE $DEV run -it --entrypoint $ENTRYPOINT wagtail "$@"
 
 elif [ $1 = "test" -o $1 = "t" ]; then
   shift

--- a/ov_wag/tests/test_api.py
+++ b/ov_wag/tests/test_api.py
@@ -1,10 +1,8 @@
-from django.urls import reverse
 from rest_framework import status
-from unittest import TestCase
 from rest_framework.test import APITestCase
-from wagtail.core.models import Page, Site
+from wagtail.core.models import Site
 import wagtail_factories
-from exhibit.models import ExhibitPage, ExhibitPageApiSchema
+from exhibit.models import ExhibitPageApiSchema
 from exhibit.tests.factories import ExhibitPageFactory
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = ov_wag.settings.dev
 python_files = tests.py test_*.py *_tests.py
+testpaths =
+  authors
+  exhibit
+  ov_wag

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = ov_wag.settings.dev
+python_files = tests.py test_*.py *_tests.py

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest >= 7.1.3, < 7.2
+pytest-django >= 4.5.2, < 4.6

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest >= 7.1.3, < 7.2
 pytest-django >= 4.5.2, < 4.6
+coverage >= 6.4.4, < 6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django >= 4.1.1, < 4.2
-wagtail >= 4.0.1, < 4.1
+wagtail >= 4.0.2, < 4.1
 wagtail_factories >= 3.1.0, < 3.2
 pydantic >= 1.10.2, < 2.0
 psycopg2 >= 2.9.3, < 2.10


### PR DESCRIPTION
# Coverage
- [x] Migrate to `pytest-django`
- [x] Add test coverage 
- [x] put badge on README: [![Coverage Status](https://coveralls.io/repos/github/WGBH-MLA/ov-wag/badge.svg)](https://coveralls.io/github/WGBH-MLA/ov-wag)
  - Current: 90.88%
  - Badge currently shows "unknown" because tests are not run against `main` branch

Full coverage report available through Coveralls: https://coveralls.io/github/WGBH-MLA/ov-wag

## pytest
Migrated from using default django tests to `pytest`
- Adds `pytest` and `pytest-django` to `requirements-test.txt`
  - Installs test requirements in dockerfile test image
- Switch test entrypoint from `python manage.py test` to `pytest`
  - Found all tests with `pytest.ini` settings (8 total)
  - All tests passing

## Generating a report
- Coverage report is generated by [Coverage](https://coverage.readthedocs.io/)
  - Runs `pytest` suite: 

`coverage run -m pytest`

### Generate the lcov file for coveralls
After running the report, run:

`coverage lcov`

### Generate a static HTML site
After running the report, run:

`coverage html`

## Actions
- Uses default coveralls action https://github.com/marketplace/actions/coveralls-github-action
- Runs `./ov coverage`
- Uploads results to coveralls.io

Closes #59