### PR TITLE
🪪 Orderable id

### DIFF
--- a/authors/api.py
+++ b/authors/api.py
@@ -4,3 +4,9 @@ from .models import Author
 
 class AuthorsAPIViewSet(BaseAPIViewSet):
     model = Author
+    listing_default_fields = [
+        'id',
+        'detail_url',
+        'name',
+        'image',
+    ]

--- a/authors/models.py
+++ b/authors/models.py
@@ -28,6 +28,7 @@ class AuthorsOrderable(Orderable):
         return self.author.image
 
     api_fields = [
+        APIField('author_id'),
         APIField('name'),
         APIField('image', serializer=ImageRenditionField('fill-100x100')),
     ]
@@ -53,6 +54,7 @@ class Author(models.Model):
     ]
 
     api_fields = [
+        APIField('id'),
         APIField('name'),
         APIField('image'),
         APIField('bio'),

--- a/authors/serializers.py
+++ b/authors/serializers.py
@@ -1,11 +1,16 @@
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer, PrimaryKeyRelatedField
 from wagtail.images.api.fields import ImageRenditionField
 from authors.models import Author
 
 
 class AuthorSerializer(ModelSerializer):
     image = ImageRenditionField('fill-100x100')
+    author_id = PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Author
-        fields = ['name', 'image']
+        fields = [
+            'author_id',
+            'name',
+            'image',
+        ]

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -35,6 +35,7 @@ class ExhibitsOrderable(Orderable):
         return self.exhibit.authors
 
     api_fields = [
+        APIField('exhibit_id'),
         APIField('title'),
         APIField(
             'cover_image',


### PR DESCRIPTION
# Orderable id
Include `author_id` and `exhibit_id` in api responses

Closes #63