### PR TITLE
🪟 Simplify `content_panels`

### DIFF
--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -85,20 +85,16 @@ class ExhibitPage(Page):
     ]
 
     content_panels = Page.content_panels + [
-        FieldPanel('body', classname='full'),
-        FieldPanel('cover_image', classname='full'),
-        FieldPanel('hero_image', classname='full'),
-        MultiFieldPanel([InlinePanel('authors', label='Author', heading='Author(s)')]),
-        MultiFieldPanel(
-            [
-                InlinePanel(
+        FieldPanel('cover_image'),
+        FieldPanel('hero_image'),
+        FieldPanel('body', classname='collapsed'),
+        InlinePanel('authors', label='Author', heading='Author(s)'),
+        InlinePanel(
                     'other_exhibits',
                     label='Other Exhibits',
                     heading='Other Exhibits',
                     max_num=3,
                 )
-            ]
-        ),
     ]
 
     api_fields = [

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -85,8 +85,10 @@ class ExhibitPage(Page):
     ]
 
     content_panels = Page.content_panels + [
-        FieldPanel('cover_image'),
-        FieldPanel('hero_image'),
+        MultiFieldPanel([
+            FieldPanel('cover_image'),
+            FieldPanel('hero_image'),
+        ], heading='Images'),
         FieldPanel('body', classname='collapsed'),
         InlinePanel('authors', label='Author', heading='Author(s)'),
         InlinePanel(

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -90,10 +90,9 @@ class ExhibitPage(Page):
             FieldPanel('hero_image'),
         ], heading='Images'),
         FieldPanel('body', classname='collapsed'),
-        InlinePanel('authors', label='Author', heading='Author(s)'),
+        InlinePanel('authors', heading='Author(s)'),
         InlinePanel(
                     'other_exhibits',
-                    label='Other Exhibits',
                     heading='Other Exhibits',
                     max_num=3,
                 )


### PR DESCRIPTION
# `content_panels`
- Simplify exhibit `content_panels` organization
  - Remove `MultiFieldPanel`, because we only have one panel in each
- Combine `Images` into `MultiFieldPanel`
- `body`: collapsed by default

## Before
![localhost_8000_admin_pages_6_edit_ (3)](https://user-images.githubusercontent.com/2718445/194381711-7d497b03-601e-4e06-935f-d2a0beb1c8d2.png)

## After
![localhost_8000_admin_pages_6_edit_ (7)](https://user-images.githubusercontent.com/2718445/194386229-9f77cb32-fcd4-476c-a1d6-cb583c6aea8e.png)
