### PR TITLE
🦤 Wagtail 4.0.4

### DIFF
--- a/ov_wag/settings/base.py
+++ b/ov_wag/settings/base.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.forms',
     'wagtail.contrib.modeladmin',
     'wagtail.contrib.redirects',
+    'wagtail.contrib.styleguide',
     'wagtail.embeds',
     'wagtail.sites',
     'wagtail.users',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django >= 4.1.1, < 4.2
-wagtail >= 4.0.2, < 4.1
+wagtail >= 4.0.4, < 4.1
 wagtail_factories >= 3.1.0, < 3.2
 pydantic >= 1.10.2, < 2.0
 psycopg2 >= 2.9.3, < 2.10


### PR DESCRIPTION
# Upgrade wagtail
Upgrade wagtail from `4.0.2` -> `4.0.4`
- [Reissue of `4.0.3` due to packaging issue](https://github.com/wagtail/wagtail/releases/tag/v4.0.4)

## Styleguide
Adds Wagtail Styleguide
- Shows available icons and styles

![Screenshot from 2022-10-19 14-34-07](https://user-images.githubusercontent.com/2718445/196809056-30463e07-e96e-4794-9227-baf28f4cfe43.png)
