### PR TITLE
♾️ Unlimited API

### DIFF
--- a/ov_wag/settings/base.py
+++ b/ov_wag/settings/base.py
@@ -219,6 +219,9 @@ WAGTAIL_HEADLESS_PREVIEW = {
     'CLIENT_URLS': {'default': os.environ.get('OV_PREVIEW_URL')},
 }
 
+# TODO: Set this to a real limit once we create pagination for the frontend endpoints
+WAGTAILAPI_LIMIT_MAX = None
+
 # OIDC Provider settings
 SITE_ID = 1
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
# API llmit
Removes default `WAGTAILAPI_LIMIT_MAX`

Closes #217

## TODO
This might affect performance eventually, so a better solution would be frontend pagination for the `/exhibits` and `/collections` routes. Then, this setting can be set to the max page limit.